### PR TITLE
Build updates

### DIFF
--- a/boris-git.toml
+++ b/boris-git.toml
@@ -39,3 +39,9 @@
 
 [build.validate]
   git = "refs/heads/topic/*"
+
+[build.submodules]
+  git = "refs/heads/master"
+
+[build.submodules-branches]
+  git = "refs/heads/topic/*"

--- a/boris-git.toml
+++ b/boris-git.toml
@@ -45,3 +45,6 @@
 
 [build.submodules-branches]
   git = "refs/heads/topic/*"
+
+[build.rebased]
+  git = "refs/heads/master"

--- a/boris-git.toml
+++ b/boris-git.toml
@@ -1,17 +1,41 @@
 [boris]
   version = 1
 
-[build.dist-7-10]
+[build.dist-7-10-core]
+  git = "refs/heads/master"
+
+[build.dist-7-10-http-client]
+  git = "refs/heads/master"
+
+[build.dist-7-10-raw]
+  git = "refs/heads/master"
+
+[build.dist-7-10-cli]
+  git = "refs/heads/master"
+
+[build.dist-7-10-export]
   git = "refs/heads/master"
 
 [build.dist-cabal-test]
   git = "refs/heads/master"
 
-[build.branches-7-10]
+[build.branches-7-10-core]
+  git = "refs/heads/topic/*"
+
+[build.branches-7-10-http-client]
+  git = "refs/heads/topic/*"
+
+[build.branches-7-10-raw]
+  git = "refs/heads/topic/*"
+
+[build.branches-7-10-cli]
+  git = "refs/heads/topic/*"
+
+[build.branches-7-10-export]
   git = "refs/heads/topic/*"
 
 [build.branches-cabal-test]
   git = "refs/heads/topic/*"
 
 [build.validate]
-  git = "refs/heads/master"
+  git = "refs/heads/topic/*"

--- a/boris-git.toml
+++ b/boris-git.toml
@@ -1,17 +1,11 @@
 [boris]
   version = 1
 
-[build.dist-7-8]
-  git = "refs/heads/master"
-
 [build.dist-7-10]
   git = "refs/heads/master"
 
 [build.dist-cabal-test]
   git = "refs/heads/master"
-
-[build.branches-7-8]
-  git = "refs/heads/topic/*"
 
 [build.branches-7-10]
   git = "refs/heads/topic/*"

--- a/boris.toml
+++ b/boris.toml
@@ -1,14 +1,6 @@
 [boris]
   version = 1
 
-[build.dist-7-8]
-  command = [
-      ["master", "build", "dist-7-8", "-C", "zodiac-core"]
-    , ["master", "build", "dist-7-8", "-C", "zodiac-http-client"]
-    , ["master", "build", "dist-7-8", "-C", "zodiac-raw"]
-    , ["master", "build", "dist-7-8", "-C", "zodiac-export"]
-    ]
-
 [build.dist-7-10]
   command = [
       ["master", "build", "dist-7-10", "-C", "zodiac-core"]
@@ -21,14 +13,6 @@
 
 [build.dist-cabal-test]
   command = [["./bin/ci.cabal-test"]]
-
-[build.branches-7-8]
-  command = [
-      ["master", "build", "branches-7-8", "-C", "zodiac-core"]
-    , ["master", "build", "branches-7-8", "-C", "zodiac-http-client"]
-    , ["master", "build", "branches-7-8", "-C", "zodiac-raw"]
-    , ["master", "build", "branches-7-8", "-C", "zodiac-export"]
-    ]
 
 [build.branches-7-10]
   command = [

--- a/framework/mafia
+++ b/framework/mafia
@@ -118,4 +118,4 @@ case "$MODE" in
 upgrade) shift; run_upgrade "$@" ;;
 *) exec_mafia "$@"
 esac
-# Version: 14254967c6b66a01a375d195a0d89918fe2da8fb
+# Version: de245376fd86c1ec9a5a451f096cb79bc8ae68f7

--- a/zodiac-core/master.toml
+++ b/zodiac-core/master.toml
@@ -7,14 +7,6 @@
   GHC_VERSION="7.10.2"
   CABAL_VERSION = "1.22.4.0"
 
-[build.dist-7-8]
-  GHC_VERSION = "7.8.4"
-  CABAL_VERSION = "1.22.4.0"
-
-[build.branches-7-8]
-  GHC_VERSION = "7.8.4"
-  CABAL_VERSION = "1.22.4.0"
-
 [build.dist-7-10]
   HADDOCK = "true"
   HADDOCK_S3 = "$AMBIATA_HADDOCK_MASTER"

--- a/zodiac-export/master.toml
+++ b/zodiac-export/master.toml
@@ -7,14 +7,6 @@
   GHC_VERSION="7.10.2"
   CABAL_VERSION = "1.22.4.0"
 
-[build.dist-7-8]
-  GHC_VERSION = "7.8.4"
-  CABAL_VERSION = "1.22.4.0"
-
-[build.branches-7-8]
-  GHC_VERSION = "7.8.4"
-  CABAL_VERSION = "1.22.4.0"
-
 [build.dist-7-10]
   HADDOCK = "true"
   HADDOCK_S3 = "$AMBIATA_HADDOCK_MASTER"

--- a/zodiac-http-client/master.toml
+++ b/zodiac-http-client/master.toml
@@ -7,14 +7,6 @@
   GHC_VERSION="7.10.2"
   CABAL_VERSION = "1.22.4.0"
 
-[build.dist-7-8]
-  GHC_VERSION = "7.8.4"
-  CABAL_VERSION = "1.22.4.0"
-
-[build.branches-7-8]
-  GHC_VERSION = "7.8.4"
-  CABAL_VERSION = "1.22.4.0"
-
 [build.dist-7-10]
   HADDOCK = "true"
   HADDOCK_S3 = "$AMBIATA_HADDOCK_MASTER"

--- a/zodiac-raw/master.toml
+++ b/zodiac-raw/master.toml
@@ -7,14 +7,6 @@
   GHC_VERSION="7.10.2"
   CABAL_VERSION = "1.22.4.0"
 
-[build.dist-7-8]
-  GHC_VERSION = "7.8.4"
-  CABAL_VERSION = "1.22.4.0"
-
-[build.branches-7-8]
-  GHC_VERSION = "7.8.4"
-  CABAL_VERSION = "1.22.4.0"
-
 [build.dist-7-10]
   HADDOCK = "true"
   HADDOCK_S3 = "$AMBIATA_HADDOCK_MASTER"


### PR DESCRIPTION
Bring in line with new best practices.

 - Drop 7.8 support.
 - Split builds by subproject (step 1).
 - Add rebased and submodules checks (step 1).

@thumphries @erikd-ambiata