### PR TITLE
build: add boris-git config for protocol subprojects

### DIFF
--- a/boris-git.toml
+++ b/boris-git.toml
@@ -4,6 +4,12 @@
 [build.dist-7-10-core]
   git = "refs/heads/master"
 
+[build.dist-7-10-tsrp]
+  git = "refs/heads/master"
+
+[build.dist-7-10-tarp]
+  git = "refs/heads/master"
+
 [build.dist-7-10-http-client]
   git = "refs/heads/master"
 
@@ -20,6 +26,12 @@
   git = "refs/heads/master"
 
 [build.branches-7-10-core]
+  git = "refs/heads/topic/*"
+
+[build.branches-7-10-tsrp]
+  git = "refs/heads/topic/*"
+
+[build.branches-7-10-tarp]
   git = "refs/heads/topic/*"
 
 [build.branches-7-10-http-client]

--- a/boris.toml
+++ b/boris.toml
@@ -1,16 +1,6 @@
 [boris]
   version = 1
 
-[build.branches-7-10]
-  command = [
-      ["master", "build", "branches-7-10", "-C", "zodiac-core"]
-    , ["master", "build", "branches-7-10", "-C", "zodiac-http-client"]
-    , ["master", "build", "branches-7-10", "-C", "zodiac-raw"]
-    , ["master", "build", "branches-7-10", "-C", "zodiac-cli"]
-    , ["./bin/ci.zodiac-publish-build"]
-    , ["master", "build", "branches-7-10", "-C", "zodiac-export"]
-    ]
-
 [build.dist-7-10-core]
   command = [["master", "build", "dist-7-10", "-C", "zodiac-core"]]
 


### PR DESCRIPTION
In preparation for split of zodiac-core.

Ref/reasoning in #63.

@erikd-ambiata @thumphries 