### PR TITLE
Implement key and key ID tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ designed for use in scripts (e.g., with `curl`).
 Example usage:
 
 ```sh
-export TSRP_KEY_ID="6451eb6f287b4d6b46ec13e36607653b"
-export TSRP_SECRET_KEY="89cf43bed574d6e6a54bf436b3a4ba8dc658973b85aa5bfc80f05e38e01d28d7"
+export TSRP_KEY_ID="DWPXY16451eb6f287b4d6b46ec13e36607653b"
+export TSRP_SECRET_KEY="LWTGZD89cf43bed574d6e6a54bf436b3a4ba8dc658973b85aa5bfc80f05e38e01d28d7"
 
 cat > req <<EOF
 GET /foo HTTP/1.1

--- a/zodiac-cli/src/Zodiac/Cli/TSRP/Data.hs
+++ b/zodiac-cli/src/Zodiac/Cli/TSRP/Data.hs
@@ -21,12 +21,12 @@ data TSRPCommand =
 -- variables on *nix, but due to potential need to support Windows we're
 -- keeping this abstract interface.
 data TSRPParams = TSRPParams {
-    tsrpSecretKey :: !SymmetricKey
+    tsrpSecretKey :: !TSRPKey
   , tsrpKeyId :: !KeyId
   } deriving (Eq)
 
 instance Show TSRPParams where
   showsPrec p (TSRPParams _sk kid) =
     showParen (p > 10) $
-      showString "TSRPParams (SymmetricKey \"<redacted>\") " .
+      showString "TSRPParams (TSRPKey \"<redacted>\") " .
       showsPrec 11 kid

--- a/zodiac-cli/src/Zodiac/Cli/TSRP/Env.hs
+++ b/zodiac-cli/src/Zodiac/Cli/TSRP/Env.hs
@@ -8,6 +8,7 @@ module Zodiac.Cli.TSRP.Env(
 
 import           Control.Monad.IO.Class (liftIO)
 
+import           Data.ByteString (ByteString)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 
@@ -25,14 +26,14 @@ import           Zodiac.Cli.TSRP.Error
 tsrpParamsFromEnv :: EitherT TSRPError IO TSRPParams
 tsrpParamsFromEnv = do
   sk <- getEnvParam "TSRP_SECRET_KEY" >>=
-          (parseParam "symmetric key" parseSymmetricKey)
+          (parseParam "symmetric key" parseTSRPKey)
   kid <- getEnvParam "TSRP_KEY_ID" >>=
-          (parseParam "key ID" (parseKeyId . T.encodeUtf8))
+          (parseParam "key ID" parseKeyId)
   pure $ TSRPParams sk kid
 
-parseParam :: Text -> (Text -> Maybe' a) -> Text -> EitherT TSRPError IO a
+parseParam :: Text -> (ByteString -> Maybe' a) -> Text -> EitherT TSRPError IO a
 parseParam var f t =
-  maybe' (left . TSRPParamError $ InvalidParam var t) pure $ f t
+  maybe' (left . TSRPParamError $ InvalidParam var t) pure $ (f . T.encodeUtf8) t
 
 getEnvParam :: Text -> EitherT TSRPError IO Text
 getEnvParam var =

--- a/zodiac-cli/test/cli/auth/run
+++ b/zodiac-cli/test/cli/auth/run
@@ -8,8 +8,8 @@ banner Authenticate request
 authed_request=$(mktemp -p dist zodiac_cli_test_XXXXXX)
 trap "rm -rf ${authed_request}" EXIT
 
-export TSRP_KEY_ID="6451eb6f287b4d6b46ec13e36607653b"
-export TSRP_SECRET_KEY="89cf43bed574d6e6a54bf436b3a4ba8dc658973b85aa5bfc80f05e38e01d28d7"
+export TSRP_KEY_ID="DWPXY16451eb6f287b4d6b46ec13e36607653b"
+export TSRP_SECRET_KEY="LWTGZD89cf43bed574d6e6a54bf436b3a4ba8dc658973b85aa5bfc80f05e38e01d28d7"
 
 cat test/data/basic-request | $TSRP authenticate -e 60 > $authed_request
 

--- a/zodiac-export/src/Zodiac/Export.hs
+++ b/zodiac-export/src/Zodiac/Export.hs
@@ -15,7 +15,7 @@ import           Zodiac.Export.TSRP
 
 foreign export ccall "_z_tsrp_gen_key_id" genKeyId :: Ptr CUChar -> IO ()
 
-foreign export ccall "_z_tsrp_gen_symmetric_key" genSymmetricKey :: Ptr CUChar -> IO ()
+foreign export ccall "_z_tsrp_gen_tsrp_key" genTSRPKey :: Ptr CUChar -> IO ()
 
 foreign export ccall "_z_tsrp_verify" verifyRawRequest' :: Ptr CChar
                                                         -> Ptr CChar

--- a/zodiac-export/src/Zodiac/Export/Key.hs
+++ b/zodiac-export/src/Zodiac/Export/Key.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Zodiac.Export.Key (
     genKeyId
-  , genSymmetricKey
+  , genTSRPKey
   ) where
 
 import           Data.ByteString.Internal (toForeignPtr, memcpy)
@@ -18,7 +18,7 @@ import           System.IO (IO)
 
 import           Tinfoil.Data.Key (SymmetricKey(..))
 
-import           Zodiac.TSRP.Data.Key (KeyId(..))
+import           Zodiac.TSRP.Data.Key (KeyId(..), TSRPKey(..))
 import qualified Zodiac.TSRP.Key as Z
 
 -- | Needs a 16B buffer.
@@ -30,9 +30,9 @@ genKeyId buf = do
     memcpy (castPtr buf) (plusPtr p offs) len
 
 -- | Needs a 32B buffer.
-genSymmetricKey :: Ptr CUChar -> IO ()
-genSymmetricKey buf = do
-  bs <- unSymmetricKey <$> Z.genSymmetricKey
+genTSRPKey :: Ptr CUChar -> IO ()
+genTSRPKey buf = do
+  bs <- (unSymmetricKey . unTSRPKey) <$> Z.genTSRPKey
   let (fp, offs, len) = toForeignPtr bs
   withForeignPtr fp $ \p ->
     memcpy (castPtr buf) (plusPtr p offs) len

--- a/zodiac-export/src/Zodiac/Export/TSRP.hs
+++ b/zodiac-export/src/Zodiac/Export/TSRP.hs
@@ -6,7 +6,6 @@ module Zodiac.Export.TSRP (
   ) where
 
 import qualified Data.ByteString as BS
-import qualified Data.Text.Encoding as T
 
 import           Foreign.C.Types (CChar, CInt, CSize, CTime)
 import           Foreign.Ptr (Ptr)
@@ -33,9 +32,8 @@ verifyRawRequest' bufKid bufSK bufReq sizeReq ts =
   bsSK <- BS.packCStringLen (bufSK, Z.tsrpSecretKeyLength)
   bsReq <- BS.packCStringLen (bufReq, fromIntegral sizeReq)
   let parsed = do
-                 tsk <- either (const Nothing') Just' $ T.decodeUtf8' bsSK
                  kid <- Z.parseKeyId bsKid
-                 sk <- Z.parseSymmetricKey tsk
+                 sk <- Z.parseTSRPKey bsSK
                  pure (kid, sk)
   case parsed of
     Nothing' ->

--- a/zodiac-http-client/src/Zodiac/HttpClient.hs
+++ b/zodiac-http-client/src/Zodiac/HttpClient.hs
@@ -8,20 +8,20 @@ TSRP requests with zodiac and should provide everything needed to do so.
 -}
 module Zodiac.HttpClient(
     KeyId
-  , SymmetricKey
+  , TSRPKey
   , SymmetricProtocol(..)
   , Verified(..)
 
-  , parseSymmetricKey
+  , parseTSRPKey
   , parseSymmetricProtocol
   , parseKeyId
   , renderKeyId
-  , renderSymmetricKey
+  , renderTSRPKey
   , renderSymmetricProtocol
 
   -- * Key generation
   , genKeyId
-  , genSymmetricKey
+  , genTSRPKey
 
   -- * Timestamps
   , RequestExpiry(..)
@@ -38,8 +38,7 @@ module Zodiac.HttpClient(
   , renderRequestError
   ) where
 
-import           Tinfoil.Data (Verified(..), SymmetricKey)
-import           Tinfoil.Data (parseSymmetricKey, renderSymmetricKey)
+import           Tinfoil.Data (Verified(..))
 
 import           Zodiac.Core.Data.Protocol
 import           Zodiac.Core.Data.Time

--- a/zodiac-http-client/src/Zodiac/HttpClient/TSRP.hs
+++ b/zodiac-http-client/src/Zodiac/HttpClient/TSRP.hs
@@ -20,7 +20,7 @@ import           P
 
 import           System.IO (IO)
 
-import           Tinfoil.Data (Verified(..), MAC, SymmetricKey)
+import           Tinfoil.Data (Verified(..), MAC)
 
 import           Zodiac.Core.Request
 import           Zodiac.TSRP.Data
@@ -33,7 +33,7 @@ import           Zodiac.HttpClient.Request
 -- Authorization header added which can be sent directly to a server
 -- supporting TSRP.
 authedHttpClientRequest :: KeyId
-                        -> SymmetricKey
+                        -> TSRPKey
                         -> RequestExpiry
                         -> Request
                         -> RequestTimestamp
@@ -48,17 +48,17 @@ authedHttpClientRequest kid sk re r rt =
 -- | Works as 'verifyHttpClientRequest'', but uses the current time to verify
 -- the request.
 verifyHttpClientRequest :: KeyId
-                        -> SymmetricKey
+                        -> TSRPKey
                         -> Request
                         -> IO Verified
 verifyHttpClientRequest kid sk r =
   getCurrentTime >>= (verifyHttpClientRequest' kid sk r)
 
 -- | Verify an authenticated http-client request. The 'KeyId' parameter
--- can be extracted with 'httpClientKeyId'; the 'SymmetricKey' should be
+-- can be extracted with 'httpClientKeyId'; the 'TSRPKey' should be
 -- the one associated with the 'KeyId'.
 verifyHttpClientRequest' :: KeyId
-                         -> SymmetricKey
+                         -> TSRPKey
                          -> Request
                          -> UTCTime
                          -> IO Verified
@@ -107,7 +107,7 @@ httpAuthHeader TSRPv1 kid rt re cr mac =
 -- converted to an http-client-compatible Authorization header using
 -- 'httpAuthHeader'.
 macHttpClientRequest :: KeyId
-                     -> SymmetricKey
+                     -> TSRPKey
                      -> RequestExpiry
                      -> Request
                      -> RequestTimestamp

--- a/zodiac-http-client/test/Test/IO/Zodiac/HttpClient/TSRP.hs
+++ b/zodiac-http-client/test/Test/IO/Zodiac/HttpClient/TSRP.hs
@@ -20,7 +20,7 @@ import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
 import           Test.Zodiac.Core.Gen
 
-import           Tinfoil.Data (Verified(..), SymmetricKey)
+import           Tinfoil.Data (Verified(..))
 
 import           Zodiac.TSRP.Data
 import           Zodiac.Core.Request
@@ -31,7 +31,7 @@ import           Zodiac.HttpClient.TSRP
 -- FIXME: rewrite once https://github.com/ambiata/tinfoil/pull/47 is merged
 prop_httpClientAuthHeader :: CRequest
                           -> KeyId
-                          -> SymmetricKey
+                          -> TSRPKey
                           -> RequestExpiry
                           -> RequestTimestamp
                           -> Property
@@ -56,7 +56,7 @@ prop_verifyHttpClientRequest' :: KeyId
                               -> RequestTimestamp
                               -> RequestExpiry
                               -> CRequest
-                              -> SymmetricKey
+                              -> TSRPKey
                               -> Property
 prop_verifyHttpClientRequest' kid rt re cr sk =
   forAll (genTimeWithin rt re) $ \now ->
@@ -73,7 +73,7 @@ prop_httpClientKeyId :: KeyId
                      -> RequestTimestamp
                      -> RequestExpiry
                      -> CRequest
-                     -> SymmetricKey
+                     -> TSRPKey
                      -> Property
 prop_httpClientKeyId kid rt re cr sk =
   let req = fromCanonicalRequest cr

--- a/zodiac-http-client/test/Test/Zodiac/HttpClient/TSRP.hs
+++ b/zodiac-http-client/test/Test/Zodiac/HttpClient/TSRP.hs
@@ -16,8 +16,6 @@ import           Test.Zodiac.TSRP.Arbitrary ()
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
 
-import           Tinfoil.Data (SymmetricKey)
-
 import           Zodiac.TSRP.Data
 import           Zodiac.HttpClient.Error
 import           Zodiac.HttpClient.Request
@@ -25,7 +23,7 @@ import           Zodiac.HttpClient.TSRP
 
 prop_authedHttpClientRequest :: CRequest
                              -> KeyId
-                             -> SymmetricKey
+                             -> TSRPKey
                              -> RequestExpiry
                              -> RequestTimestamp
                              -> Property

--- a/zodiac-raw/src/Zodiac/Raw.hs
+++ b/zodiac-raw/src/Zodiac/Raw.hs
@@ -8,20 +8,20 @@ TSRP requests with zodiac and should provide everything needed to do so.
 -}
 module Zodiac.Raw(
     KeyId
-  , SymmetricKey
+  , TSRPKey
   , SymmetricProtocol(..)
   , Verified(..)
 
   , parseKeyId
-  , parseSymmetricKey
+  , parseTSRPKey
   , parseSymmetricProtocol
   , renderKeyId
-  , renderSymmetricKey
+  , renderTSRPKey
   , renderSymmetricProtocol
 
   -- * Key generation
   , genKeyId
-  , genSymmetricKey
+  , genTSRPKey
 
   -- * Timestamps
   , RequestExpiry(..)
@@ -38,9 +38,7 @@ module Zodiac.Raw(
   , renderRequestError
   ) where
 
-import           Tinfoil.Data (Verified(..), SymmetricKey)
-import           Tinfoil.Data (parseSymmetricKey, renderSymmetricKey)
-
+import           Tinfoil.Data (Verified(..))
 
 import           Zodiac.Core.Data.Protocol
 import           Zodiac.Core.Data.Time

--- a/zodiac-raw/src/Zodiac/Raw/TSRP.hs
+++ b/zodiac-raw/src/Zodiac/Raw/TSRP.hs
@@ -22,7 +22,7 @@ import           P hiding ((<>))
 
 import           System.IO (IO)
 
-import           Tinfoil.Data (Verified(..), MAC, SymmetricKey)
+import           Tinfoil.Data (Verified(..), MAC)
 
 import           Zodiac.Core.Request
 import           Zodiac.TSRP.Data
@@ -35,7 +35,7 @@ import           Zodiac.Raw.Request
 -- Authorization header added which can be sent directly to a server
 -- supporting TSRP.
 authedRawRequest :: KeyId
-                 -> SymmetricKey
+                 -> TSRPKey
                  -> RequestExpiry
                  -> ByteString
                  -> RequestTimestamp
@@ -53,14 +53,14 @@ authedRawRequest kid sk re bs rt = do
       HTTPV1_1Request $ req { H.hrqv1_1Headers = newHs }
 
 verifyRawRequest :: KeyId
-                 -> SymmetricKey
+                 -> TSRPKey
                  -> ByteString
                  -> IO Verified
 verifyRawRequest kid sk bs =
   getCurrentTime >>= verifyRawRequest' kid sk bs
 
 verifyRawRequest' :: KeyId
-                  -> SymmetricKey
+                  -> TSRPKey
                   -> ByteString
                   -> UTCTime
                   -> IO Verified
@@ -75,7 +75,7 @@ verifyRawRequest' kid sk bs now =
 
 -- | Create a detached MAC of a hadron 'HTTPRequest'.
 macHadronRequest :: KeyId
-                 -> SymmetricKey
+                 -> TSRPKey
                  -> RequestExpiry
                  -> H.HTTPRequest
                  -> RequestTimestamp

--- a/zodiac-raw/test/Test/IO/Zodiac/Raw/TSRP.hs
+++ b/zodiac-raw/test/Test/IO/Zodiac/Raw/TSRP.hs
@@ -19,7 +19,7 @@ import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
 import           Test.Zodiac.Core.Gen
 
-import           Tinfoil.Data (Verified(..), SymmetricKey)
+import           Tinfoil.Data (Verified(..))
 
 import           Zodiac.TSRP.Data
 import           Zodiac.Raw.Error
@@ -30,7 +30,7 @@ prop_verifyRawRequest' :: KeyId
                        -> RequestTimestamp
                        -> RequestExpiry
                        -> CRequest
-                       -> SymmetricKey
+                       -> TSRPKey
                        -> Property
 prop_verifyRawRequest' kid rt re cr sk =
   forAll (genTimeWithin rt re) $ \now ->
@@ -43,7 +43,7 @@ prop_verifyRawRequest' kid rt re cr sk =
         pure $ r === Verified
 
 prop_verifyRawRequest_junk :: KeyId
-                           -> SymmetricKey
+                           -> TSRPKey
                            -> UTCTime
                            -> ByteString
                            -> Property

--- a/zodiac-raw/test/Test/Zodiac/Raw/TSRP.hs
+++ b/zodiac-raw/test/Test/Zodiac/Raw/TSRP.hs
@@ -19,15 +19,13 @@ import           Test.Zodiac.TSRP.Arbitrary ()
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
 
-import           Tinfoil.Data (SymmetricKey)
-
 import           Zodiac.TSRP.Data
 import           Zodiac.Raw.Request
 import           Zodiac.Raw.TSRP
 
 prop_authedRawRequest :: CRequest
                       -> KeyId
-                      -> SymmetricKey
+                      -> TSRPKey
                       -> RequestExpiry
                       -> RequestTimestamp
                       -> Property

--- a/zodiac-tsrp/src/Zodiac/TSRP/Data/Key.hs
+++ b/zodiac-tsrp/src/Zodiac/TSRP/Data/Key.hs
@@ -22,8 +22,8 @@ import           P
 
 import           Tinfoil.Encode (hexEncode)
 
--- | Identifier for either a symmetric or asymmetric key. Should be
--- globally unique. Sixteen bytes long.
+-- | Identifier for a TSRP key. Should be globally unique. Sixteen bytes long
+-- plus six byte for the tag prefix.
 newtype KeyId =
   KeyId {
     unKeyId :: ByteString

--- a/zodiac-tsrp/src/Zodiac/TSRP/Data/Key.hs
+++ b/zodiac-tsrp/src/Zodiac/TSRP/Data/Key.hs
@@ -29,7 +29,7 @@ import           Tinfoil.Data.Key (parseSymmetricKey, renderSymmetricKey)
 import           Tinfoil.Encode (hexEncode)
 
 -- | Identifier for a TSRP key. Should be globally unique. Sixteen bytes long
--- plus six byte for the tag prefix.
+-- plus six bytes for the tag prefix.
 newtype KeyId =
   KeyId {
     unKeyId :: ByteString

--- a/zodiac-tsrp/src/Zodiac/TSRP/Key.hs
+++ b/zodiac-tsrp/src/Zodiac/TSRP/Key.hs
@@ -9,7 +9,7 @@ import           P
 
 import           System.IO (IO)
 
-import           Tinfoil.Data (Entropy(..), SymmetricKey)
+import           Tinfoil.Data (Entropy(..))
 import qualified Tinfoil.Key as Tinfoil
 import           Tinfoil.Random (entropy)
 
@@ -22,5 +22,5 @@ genKeyId = fmap (KeyId . unEntropy) $ entropy 16
 -- | Generate a symmetric key for use in the TSRP protocol. This key
 -- is shared between the server and client but kept secret from all
 -- other parties.
-genSymmetricKey :: IO SymmetricKey
-genSymmetricKey = Tinfoil.genSymmetricKey
+genSymmetricKey :: IO TSRPKey
+genSymmetricKey = TSRPKey <$> Tinfoil.genSymmetricKey

--- a/zodiac-tsrp/src/Zodiac/TSRP/Key.hs
+++ b/zodiac-tsrp/src/Zodiac/TSRP/Key.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Zodiac.TSRP.Key(
     genKeyId
-  , genSymmetricKey
+  , genTSRPKey
   ) where
 
 import           P
@@ -22,5 +22,5 @@ genKeyId = fmap (KeyId . unEntropy) $ entropy 16
 -- | Generate a symmetric key for use in the TSRP protocol. This key
 -- is shared between the server and client but kept secret from all
 -- other parties.
-genSymmetricKey :: IO TSRPKey
-genSymmetricKey = TSRPKey <$> Tinfoil.genSymmetricKey
+genTSRPKey :: IO TSRPKey
+genTSRPKey = TSRPKey <$> Tinfoil.genSymmetricKey

--- a/zodiac-tsrp/src/Zodiac/TSRP/MAC.hs
+++ b/zodiac-tsrp/src/Zodiac/TSRP/MAC.hs
@@ -20,8 +20,8 @@ import           Zodiac.TSRP.Data
 -- | Derive the key we actually use to authenticate the request from the
 -- secret key, the key ID and the date part of the request timestamp
 -- via an iterated chain of keyed hashes.
-deriveRequestKey :: SymmetricProtocol -> RequestDate -> KeyId -> SymmetricKey -> SymmetricKey
-deriveRequestKey TSRPv1 rd (KeyId kid) (SymmetricKey sk) =
+deriveRequestKey :: SymmetricProtocol -> RequestDate -> KeyId -> TSRPKey -> SymmetricKey
+deriveRequestKey TSRPv1 rd (KeyId kid) (TSRPKey (SymmetricKey sk)) =
   let k0 = SymmetricKey $ sk <> renderRequestDate rd
       k1 = chainNext $ hmacSHA256 k0 kid
       k2 = chainNext $ hmacSHA256 k1 proto in

--- a/zodiac-tsrp/src/Zodiac/TSRP/Symmetric.hs
+++ b/zodiac-tsrp/src/Zodiac/TSRP/Symmetric.hs
@@ -16,7 +16,7 @@ import           P
 
 import           System.IO (IO)
 
-import           Tinfoil.Data (Verified(..), MAC, SymmetricKey)
+import           Tinfoil.Data (Verified(..), MAC)
 import           Tinfoil.Data (KeyedHashFunction(..), HashFunction(..))
 import           Tinfoil.Data (renderHash)
 import           Tinfoil.Hash (hash)
@@ -33,7 +33,7 @@ macRequest :: SymmetricProtocol
            -> RequestTimestamp
            -> RequestExpiry
            -> CRequest
-           -> SymmetricKey
+           -> TSRPKey
            -> MAC
 macRequest TSRPv1 kid rts re cr sk =
   let authKey = deriveRequestKey TSRPv1 (timestampDate rts) kid sk
@@ -42,11 +42,11 @@ macRequest TSRPv1 kid rts re cr sk =
 
 -- | Verify a request and authentication header.
 --
--- The provided 'KeyId' and 'SymmetricKey' should be those stored by the
+-- The provided 'KeyId' and 'TSRPKey' should be those stored by the
 -- server. The key ID will be checked against the one contained in the
 -- 'SymmetricAuthHeader'.
 verifyRequest :: KeyId
-              -> SymmetricKey
+              -> TSRPKey
               -> CRequest
               -> SymmetricAuthHeader
               -> UTCTime
@@ -79,7 +79,7 @@ verifyRequest' :: SymmetricProtocol
                -> RequestTimestamp
                -> RequestExpiry
                -> StrippedCRequest
-               -> SymmetricKey
+               -> TSRPKey
                -> MAC
                -> UTCTime
                -> IO Verified

--- a/zodiac-tsrp/test/Test/IO/Zodiac/TSRP/Symmetric.hs
+++ b/zodiac-tsrp/test/Test/IO/Zodiac/TSRP/Symmetric.hs
@@ -29,7 +29,7 @@ prop_verifyRequest' :: SymmetricProtocol
                     -> RequestTimestamp
                     -> RequestExpiry
                     -> CRequest
-                    -> SymmetricKey
+                    -> TSRPKey
                     -> Property
 prop_verifyRequest' sp kid rt re cr sk =
   forAll (genTimeWithin rt re) $ \now ->
@@ -42,7 +42,7 @@ prop_verifyRequest_key' :: SymmetricProtocol
                         -> RequestTimestamp
                         -> RequestExpiry
                         -> CRequest
-                        -> UniquePair SymmetricKey
+                        -> UniquePair TSRPKey
                         -> Property
 prop_verifyRequest_key' sp kid rt re cr (UniquePair sk1 sk2) =
   forAll (genTimeWithin rt re) $ \now ->
@@ -55,7 +55,7 @@ prop_verifyRequest_req' :: SymmetricProtocol
                         -> RequestTimestamp
                         -> RequestExpiry
                         -> UniquePair CRequest
-                        -> SymmetricKey
+                        -> TSRPKey
                         -> Property
 prop_verifyRequest_req' sp kid rt re (UniquePair cr1 cr2) sk =
   forAll (genTimeWithin rt re) $ \now ->
@@ -68,7 +68,7 @@ prop_verifyRequest_before' :: SymmetricProtocol
                            -> RequestTimestamp
                            -> RequestExpiry
                            -> CRequest
-                           -> SymmetricKey
+                           -> TSRPKey
                            -> Property
 prop_verifyRequest_before' sp kid rt re cr sk =
   forAll (genTimeBefore (RequestTimestamp $ addUTCTime (- maxClockSkew) (unRequestTimestamp rt))) $ \now ->
@@ -81,7 +81,7 @@ prop_verifyRequest_after' :: SymmetricProtocol
                           -> RequestTimestamp
                           -> RequestExpiry
                           -> CRequest
-                          -> SymmetricKey
+                          -> TSRPKey
                           -> Property
 prop_verifyRequest_after' sp kid rt re cr sk =
   forAll (genTimeExpired rt re) $ \now ->
@@ -94,7 +94,7 @@ prop_verifyRequest :: SymmetricProtocol
                    -> RequestTimestamp
                    -> RequestExpiry
                    -> CRequest
-                   -> SymmetricKey
+                   -> TSRPKey
                    -> Property
 prop_verifyRequest sp kid rt re cr sk =
   forAll (genTimeWithin rt re) $ \now ->
@@ -109,7 +109,7 @@ prop_verifyRequest_kid :: SymmetricProtocol
                        -> RequestTimestamp
                        -> RequestExpiry
                        -> CRequest
-                       -> SymmetricKey
+                       -> TSRPKey
                        -> Property
 prop_verifyRequest_kid sp (UniquePair kid kid') rt re cr sk =
   forAll (genTimeWithin rt re) $ \now ->

--- a/zodiac-tsrp/test/Test/Zodiac/TSRP/Arbitrary.hs
+++ b/zodiac-tsrp/test/Test/Zodiac/TSRP/Arbitrary.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Test.Zodiac.TSRP.Arbitrary where
 
@@ -23,3 +24,8 @@ instance Arbitrary SymmetricAuthHeader where
                                   <*> arbitrary
                                   <*> arbitrary
                                   <*> arbitrary
+
+instance Arbitrary TSRPKey where
+  arbitrary = TSRPKey <$> arbitrary
+
+deriving instance Show TSRPKey

--- a/zodiac-tsrp/test/Test/Zodiac/TSRP/Data/Key.hs
+++ b/zodiac-tsrp/test/Test/Zodiac/TSRP/Data/Key.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Zodiac.TSRP.Data.Key where
+
+import           Disorder.Core (tripping)
+import           Disorder.Core.Run (ExpectedTestSpeed(..), disorderCheckEnvAll)
+
+import           P
+
+import           System.IO (IO)
+
+import           Test.Zodiac.TSRP.Arbitrary ()
+import           Test.QuickCheck
+import           Test.QuickCheck.Instances ()
+
+import           Zodiac.TSRP.Data.Key
+
+prop_tripping_KeyId :: KeyId -> Property
+prop_tripping_KeyId = tripping renderKeyId parseKeyId
+
+prop_tripping_TSRPKey :: TSRPKey -> Property
+prop_tripping_TSRPKey = tripping renderTSRPKey parseTSRPKey
+
+return []
+tests :: IO Bool
+tests = $disorderCheckEnvAll TestRunMore

--- a/zodiac-tsrp/test/Test/Zodiac/TSRP/MAC.hs
+++ b/zodiac-tsrp/test/Test/Zodiac/TSRP/MAC.hs
@@ -15,24 +15,22 @@ import           Test.Zodiac.TSRP.Arbitrary ()
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
 
-import           Tinfoil.Data.Key (SymmetricKey(..))
-
 import           Zodiac.TSRP.Data
 import           Zodiac.TSRP.MAC
 
-prop_deriveRequestKey_timestamp :: SymmetricProtocol -> UniquePair RequestDate -> KeyId -> SymmetricKey -> Property
+prop_deriveRequestKey_timestamp :: SymmetricProtocol -> UniquePair RequestDate -> KeyId -> TSRPKey -> Property
 prop_deriveRequestKey_timestamp p (UniquePair rt rt') kid sk =
   let k = deriveRequestKey p rt kid sk
       k' = deriveRequestKey p rt' kid sk in
   k =/= k'
 
-prop_deriveRequestKey_key_id :: SymmetricProtocol -> RequestDate -> UniquePair KeyId -> SymmetricKey -> Property
+prop_deriveRequestKey_key_id :: SymmetricProtocol -> RequestDate -> UniquePair KeyId -> TSRPKey -> Property
 prop_deriveRequestKey_key_id p rt (UniquePair kid kid') sk =
   let k = deriveRequestKey p rt kid sk
       k' = deriveRequestKey p rt kid' sk in
   k =/= k'
 
-prop_deriveRequestKey_key :: SymmetricProtocol -> RequestDate -> KeyId -> UniquePair (Blind SymmetricKey) -> Property
+prop_deriveRequestKey_key :: SymmetricProtocol -> RequestDate -> KeyId -> UniquePair (Blind TSRPKey) -> Property
 prop_deriveRequestKey_key p rt kid (UniquePair (Blind sk) (Blind sk')) =
   let k = deriveRequestKey p rt kid sk
       k' = deriveRequestKey p rt kid sk' in

--- a/zodiac-tsrp/test/test.hs
+++ b/zodiac-tsrp/test/test.hs
@@ -1,9 +1,11 @@
 import           Disorder.Core.Main
 
+import qualified Test.Zodiac.TSRP.Data.Key
 import qualified Test.Zodiac.TSRP.MAC
 
 main :: IO ()
 main =
   disorderMain [
-    Test.Zodiac.TSRP.MAC.tests
+    Test.Zodiac.TSRP.Data.Key.tests
+  , Test.Zodiac.TSRP.MAC.tests
   ]


### PR DESCRIPTION
Implement spec changes in #62, adding tags to key and key ID for easy identification and grepping purposes.

@erikd-ambiata @thumphries 