### PR TITLE
Export RequestTimestamp from interface modules

### DIFF
--- a/zodiac-http-client/src/Zodiac/HttpClient.hs
+++ b/zodiac-http-client/src/Zodiac/HttpClient.hs
@@ -9,6 +9,7 @@ TSRP requests with zodiac and should provide everything needed to do so.
 module Zodiac.HttpClient(
     KeyId
   , TSRPKey
+  , RequestTimestamp(..)
   , SymmetricProtocol(..)
   , Verified(..)
 

--- a/zodiac-raw/src/Zodiac/Raw.hs
+++ b/zodiac-raw/src/Zodiac/Raw.hs
@@ -9,6 +9,7 @@ TSRP requests with zodiac and should provide everything needed to do so.
 module Zodiac.Raw(
     KeyId
   , TSRPKey
+  , RequestTimestamp(..)
   , SymmetricProtocol(..)
   , Verified(..)
 


### PR DESCRIPTION
It's needed to construct authed requests, so should be exported from interface modules.

! @thumphries @erikd-ambiata 