### PR TITLE
cli: convert unix line-endings before parsing request

### DIFF
--- a/zodiac-cli/ambiata-zodiac-cli.cabal
+++ b/zodiac-cli/ambiata-zodiac-cli.cabal
@@ -40,6 +40,8 @@ library
   exposed-modules:
                        Paths_ambiata_zodiac_cli
                        Zodiac.Cli
+                       Zodiac.Cli.Data
+                       Zodiac.Cli.Process
                        Zodiac.Cli.Request
                        Zodiac.Cli.TSRP.Commands
                        Zodiac.Cli.TSRP.Data

--- a/zodiac-cli/main/tsrp.hs
+++ b/zodiac-cli/main/tsrp.hs
@@ -37,8 +37,8 @@ main = do
 
 run :: TSRPCommand -> IO ()
 run c = case c of
-  TSRPAuth re ->
-    BS.putStr =<< (orDie renderTSRPError $ TSRP.authenticate re)
-  TSRPVerify ->
-    orDie renderTSRPError TSRP.verify
+  TSRPAuth le re ->
+    BS.putStr =<< (orDie renderTSRPError $ TSRP.authenticate le re)
+  TSRPVerify le ->
+    orDie renderTSRPError $ TSRP.verify le
 

--- a/zodiac-cli/src/Zodiac/Cli/Data.hs
+++ b/zodiac-cli/src/Zodiac/Cli/Data.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
+module Zodiac.Cli.Data(
+    LineEndings(..)
+  ) where
+
+import           P
+
+-- | Line endings in the input. If they're UNIX, we need to convert them before
+-- they can be parsed as an HTTP request.
+data LineEndings =
+    LF
+  | CRLF
+  deriving (Eq, Show)

--- a/zodiac-cli/src/Zodiac/Cli/Process.hs
+++ b/zodiac-cli/src/Zodiac/Cli/Process.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Zodiac.Cli.Process(
+    preprocess
+  ) where
+
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+
+import           P
+
+import           Zodiac.Cli.Data
+
+-- | Convert line endings if we need to.
+preprocess :: LineEndings -> ByteString -> ByteString
+preprocess CRLF =
+  id
+preprocess LF =
+  -- Split on \n, unite with \r\n.
+  BS.intercalate crlf . BS.split 0x0a
+
+crlf :: ByteString
+crlf = BS.pack [0x0d, 0x0a]

--- a/zodiac-cli/src/Zodiac/Cli/TSRP/Data.hs
+++ b/zodiac-cli/src/Zodiac/Cli/TSRP/Data.hs
@@ -4,15 +4,17 @@
 module Zodiac.Cli.TSRP.Data(
     TSRPCommand(..)
   , TSRPParams(..)
+  , LineEndings(..)
   ) where
 
 import           P
 
+import           Zodiac.Cli.Data (LineEndings(..))
 import           Zodiac.Raw
 
 data TSRPCommand =
-    TSRPAuth !RequestExpiry
-  | TSRPVerify
+    TSRPAuth !LineEndings !RequestExpiry
+  | TSRPVerify !LineEndings
   deriving (Eq, Show)
 
 -- | Parameters required for auth/verification.

--- a/zodiac-cli/src/Zodiac/Cli/TSRP/Parser.hs
+++ b/zodiac-cli/src/Zodiac/Cli/TSRP/Parser.hs
@@ -13,6 +13,7 @@ import           P
 
 import           X.Options.Applicative
 
+import           Zodiac.Cli.Data
 import           Zodiac.Cli.TSRP.Data
 import           Zodiac.Raw
 
@@ -22,10 +23,10 @@ tsrpCommandP = subparser $
   <> command' "verify" "Verify the authentication of an HTTP request read from standard input." verifyP
 
 authP :: Parser TSRPCommand
-authP = TSRPAuth <$> requestExpiryP
+authP = TSRPAuth <$> lineEndingsP <*> requestExpiryP
 
 verifyP :: Parser TSRPCommand
-verifyP = pure TSRPVerify
+verifyP = TSRPVerify <$> lineEndingsP
 
 requestExpiryP :: Parser RequestExpiry
 requestExpiryP = option (eitherReader requestExpiryR) $
@@ -38,3 +39,9 @@ requestExpiryP = option (eitherReader requestExpiryR) $
     requestExpiryR x = case parseRequestExpiry (BSC.pack x) of
       Nothing' -> Left $ "invalid request expiry: " <> x
       Just' re -> pure re
+
+lineEndingsP :: Parser LineEndings
+lineEndingsP = flag CRLF LF $
+     short 'u'
+  <> long "unix-line-endings"
+  <> help "Convert UNIX line-endings into CRLF in the provided HTTP request."

--- a/zodiac-cli/test/cli/auth-unix/run
+++ b/zodiac-cli/test/cli/auth-unix/run
@@ -1,0 +1,19 @@
+#!/bin/sh -eu
+
+. $(dirname $0)/../core/setup.sh
+
+banner Authenticate request
+#--------------------------
+
+authed_request=$(mktemp -p dist zodiac_cli_test_XXXXXX)
+trap "rm -rf ${authed_request}" EXIT
+
+export TSRP_KEY_ID="DWPXY16451eb6f287b4d6b46ec13e36607653b"
+export TSRP_SECRET_KEY="LWTGZD89cf43bed574d6e6a54bf436b3a4ba8dc658973b85aa5bfc80f05e38e01d28d7"
+
+cat test/data/unix-request | $TSRP authenticate -u -e 60 > $authed_request
+
+banner Verify request
+#--------------------
+
+cat $authed_request | $TSRP verify

--- a/zodiac-cli/test/data/unix-request
+++ b/zodiac-cli/test/data/unix-request
@@ -1,0 +1,5 @@
+GET /foo HTTP/1.1
+Host: localhost
+User-Agent: curl/7.49.1
+Accept: */*
+


### PR DESCRIPTION
Just a convenience - it's difficult to manually construct valid HTTP requests using the usual UNIX tools without passing it through `unix2dos` or similar first. Add an option to the CLI so we don't have to do that.

Fixes #70.

! @charleso 

(will follow up a more curl-friendly interface in #71)