### PR TITLE
Debug output auth string

### DIFF
--- a/zodiac-cli/ambiata-zodiac-cli.cabal
+++ b/zodiac-cli/ambiata-zodiac-cli.cabal
@@ -24,6 +24,7 @@ library
                      , ambiata-x-optparse
                      , ambiata-zodiac-core
                      , ambiata-zodiac-raw
+                     , ambiata-zodiac-tsrp
                      , bytestring                      == 0.10.*
                      , deepseq-generics                == 0.2.0.*
                      , optparse-applicative            == 0.12.*

--- a/zodiac-cli/main/tsrp.hs
+++ b/zodiac-cli/main/tsrp.hs
@@ -41,4 +41,5 @@ run c = case c of
     BS.putStr =<< (orDie renderTSRPError $ TSRP.authenticate le re)
   TSRPVerify le ->
     orDie renderTSRPError $ TSRP.verify le
-
+  TSRPDebugAuthString le re ->
+    BS.putStr =<< (orDie renderTSRPError $ TSRP.stringToAuthenticate le re)

--- a/zodiac-cli/src/Zodiac/Cli/TSRP/Commands.hs
+++ b/zodiac-cli/src/Zodiac/Cli/TSRP/Commands.hs
@@ -4,6 +4,7 @@
 module Zodiac.Cli.TSRP.Commands(
     authenticate
   , verify
+  , stringToAuthenticate
   ) where
 
 import           Control.Monad.IO.Class (liftIO)
@@ -22,6 +23,8 @@ import           Zodiac.Cli.TSRP.Data
 import           Zodiac.Cli.TSRP.Env
 import           Zodiac.Cli.TSRP.Error
 import           Zodiac.Raw
+import qualified Zodiac.Raw.Request as Z
+import qualified Zodiac.TSRP.Symmetric as Z
 
 -- | Read an HTTP request to authenticate from stdin and write the
 -- authenticated request to stdout. Key ID and secret key are read
@@ -43,3 +46,14 @@ verify le = do
     Verified -> pure ()
     NotVerified -> left TSRPRequestNotVerifiedError
     VerificationError -> left TSRPVerificationError
+
+-- | Read an HTTP request to authenticate from stdin and write the
+-- corresponding string-to-authenticate to stdout.
+stringToAuthenticate :: LineEndings -> RequestExpiry -> EitherT TSRPError IO ByteString
+stringToAuthenticate le re = do
+  bs <- liftIO . fmap (preprocess le) $ BS.getContents
+  (TSRPParams _sk kid) <- tsrpParamsFromEnv
+  rt <- liftIO timestampRequest
+  cr <- firstEitherT TSRPRequestError . hoistEither $ Z.toCanonicalRequest bs
+  pure $ Z.authenticationString TSRPv1 kid rt re cr
+

--- a/zodiac-cli/src/Zodiac/Cli/TSRP/Data.hs
+++ b/zodiac-cli/src/Zodiac/Cli/TSRP/Data.hs
@@ -15,6 +15,7 @@ import           Zodiac.Raw
 data TSRPCommand =
     TSRPAuth !LineEndings !RequestExpiry
   | TSRPVerify !LineEndings
+  | TSRPDebugAuthString !LineEndings !RequestExpiry
   deriving (Eq, Show)
 
 -- | Parameters required for auth/verification.

--- a/zodiac-cli/src/Zodiac/Cli/TSRP/Parser.hs
+++ b/zodiac-cli/src/Zodiac/Cli/TSRP/Parser.hs
@@ -21,12 +21,17 @@ tsrpCommandP :: Parser TSRPCommand
 tsrpCommandP = subparser $
      command' "authenticate" "Authenticate an HTTP request read from standard input and write the authenticated request to standard output." authP
   <> command' "verify" "Verify the authentication of an HTTP request read from standard input." verifyP
+  <> command' "debug" "Access debugging information and intermediate results." debugCommandP
 
 authP :: Parser TSRPCommand
 authP = TSRPAuth <$> lineEndingsP <*> requestExpiryP
 
 verifyP :: Parser TSRPCommand
 verifyP = TSRPVerify <$> lineEndingsP
+
+debugCommandP :: Parser TSRPCommand
+debugCommandP = subparser $
+     command' "auth-string" "Derive string to authenticate and output it without computing the MAC." (TSRPDebugAuthString <$> lineEndingsP <*> requestExpiryP)
 
 requestExpiryP :: Parser RequestExpiry
 requestExpiryP = option (eitherReader requestExpiryR) $

--- a/zodiac-cli/test/cli/basic-usage/run
+++ b/zodiac-cli/test/cli/basic-usage/run
@@ -16,6 +16,10 @@ $TSRP -h
 
 $TSRP --help
 
+$TSRP debug -h
+
+$TSRP debug --help
+
 TSRP="$TSRP --dry-run"
 
 $TSRP authenticate
@@ -23,6 +27,12 @@ $TSRP authenticate
 $TSRP authenticate -e 60
 
 $TSRP verify
+
+$TSRP debug auth-string
+
+$TSRP debug auth-string -e 100
+
+$TSRP debug auth-string -u -e 100
 
 banner REQTOOL Display Version
 #--------------------------

--- a/zodiac-cli/test/cli/debug/run
+++ b/zodiac-cli/test/cli/debug/run
@@ -1,0 +1,17 @@
+#!/bin/sh -eu
+
+. $(dirname $0)/../core/setup.sh
+
+banner debug: auth string
+#--------------------------
+
+auth_string=$(mktemp -p dist zodiac_cli_test_XXXXXX)
+trap "rm -rf ${auth_string}" EXIT
+
+export TSRP_KEY_ID="DWPXY16451eb6f287b4d6b46ec13e36607653b"
+export TSRP_SECRET_KEY="LWTGZD89cf43bed574d6e6a54bf436b3a4ba8dc658973b85aa5bfc80f05e38e01d28d7"
+
+cat test/data/basic-request | $TSRP debug auth-string -e 60 > $auth_string
+
+cat $auth_string | grep -q $TSRP_KEY_ID
+cat $auth_string | tail -n 1 | grep -q 181b0189614a8840c5031bcc652efe7153c337f46c67002c9fc7c0f65d0cdc0e


### PR DESCRIPTION
Another thing I wrote while doing examples for the doc (ref #76). Given it's not all that certain that request canonicalisation will continue to be common logic once TARP arrives, I think after this I'll move the command from #76 to here under `tsrp debug` (and remove the `reqtool` executable).

! @thumphries @erikd-ambiata 