### PR TITLE
Canonicalise empty path to "/"

### DIFF
--- a/doc/spec/TARPv1.md
+++ b/doc/spec/TARPv1.md
@@ -210,10 +210,16 @@ Request URI
 The *request URI* field shall consist of the part of the request URL
 between the last character of the host part of the URL and the '?'
 character preceding the query-string part of the URL, exclusive. This
-is also referred to as the request path. If the URL does not have a
-query-string part, the URI shall continue to the end of the URL string.
+is also referred to as the request path.
 
-The request URI field shall be URL-encoded.
+ - If the URL does not have a query-string part, the URI shall continue
+   to the end of the URL string.
+
+ - If the request path is empty (for example, in the URLs
+   "https://example.com" and "https://example.com?foo=bar"), the
+   *request URI* shall be "/" (the ASCII byte `0x2f`).
+
+ - The request URI field shall be URL-encoded.
 
 Example values for this field are "/" and "/example/page.html".
 

--- a/doc/spec/TSRPv1.md
+++ b/doc/spec/TSRPv1.md
@@ -206,10 +206,16 @@ Request URI
 The *request URI* field shall consist of the part of the request URL
 between the last character of the host part of the URL and the '?'
 character preceding the query-string part of the URL, exclusive. This
-is also referred to as the request path. If the URL does not have a
-query-string part, the URI shall continue to the end of the URL string.
+is also referred to as the request path.
 
-The request URI field shall be URL-encoded.
+ - If the URL does not have a query-string part, the URI shall continue
+   to the end of the URL string.
+
+ - If the request path is empty (for example, in the URLs
+   "https://example.com" and "https://example.com?foo=bar"), the
+   *request URI* shall be "/" (the ASCII byte `0x2f`).
+
+ - The request URI field shall be URL-encoded.
 
 Example values for this field are "/" and "/example/page.html".
 


### PR DESCRIPTION
https://github.com/ambiata/zodiac/issues/97

Currently, requests for "https://example.com?foo=bar" and "https://example.com/?foo=bar" are considered distinct in the `http-client` interface package. The `core` and `raw` packages aren't affected by this as they only deal with HTTP requests (as opposed to the URIs used by user-agents). It's not totally clear from the spec what the correct behaviour is, but it seems to me that semantically there is no reason to distinguish them, especially as [the distinction disappears as soon as the HTTP request is constructed anyway](https://tools.ietf.org/html/rfc2616#section-5.1.2).

This patch explicates that an empty path should be canonicalised to `/`. Grab me if anyone thinks this is a bad idea or wants to go over in more detail.

! @erikd-ambiata @charleso @markhibberd @NaevaTheCat 
/jury approved @markhibberd @charleso @NaevaTheCat